### PR TITLE
Structure change under "all_bes_repos"

### DIFF
--- a/bes_theme/assets/data/OSSP-master.js
+++ b/bes_theme/assets/data/OSSP-master.js
@@ -1,0 +1,63 @@
+[
+    {
+        "id": 50,
+        "bes_tracking_id": 50,
+        "name": "prometheus",
+        "description": "The Prometheus monitoring system and time series database.",
+        "cvedetails": {                                                  
+            "bes_cve_details_id": "",                      
+            "cvedetails_product_id": "61503",                      
+            "cvedetails_vendor_id": "20905"
+        }, 
+        "project_repos": {
+            "main_github_url": "https://github.com/prometheus/prometheus",
+            "main_bes_url": "https://github.com/Be-Secure/prometheus",
+            "all_projects": {                                                                         
+                "main_project_xxx" : "",
+                "sub_project_xxx":""
+            },
+            "all_bes_repos": {                                                                      
+                 "sub_project_xxx":""
+           }   
+        },
+        "license": {
+            "key": "apache-2.0",
+            "name": "Apache License 2.0",
+            "spdx_id": "Apache-2.0",
+            "url": "https://api.github.com/licenses/apache-2.0",
+            "node_id": "MDc6TGljZW5zZTI="
+          },   
+        "language": [
+
+            "Go",
+            "TypeScript",
+            "JavaScript",
+            "HTML",
+            "Yacc",
+            "SCSS",
+            "CSS",
+            "Shell",
+            "Lex",
+            "Makefile",
+            "Dockerfile"
+
+        ],
+        "tags": {
+            "IND": [
+                "ALL"
+            ],
+            "SD": [
+                "SD-SOC"
+            ],
+            "COM": {
+                "foundation": "CNCF"
+            },
+            "TD-U": [
+                "TD-U-DAA"
+            ]
+
+        }
+            
+          
+    }
+]

--- a/bes_theme/assets/data/OSSP-master.js
+++ b/bes_theme/assets/data/OSSP-master.js
@@ -1,6 +1,7 @@
 [
     {
         "id": 50,
+        "github_id": 391939220,
         "bes_tracking_id": 50,
         "name": "prometheus",
         "description": "The Prometheus monitoring system and time series database.",

--- a/bes_theme/assets/data/OSSP-master.js
+++ b/bes_theme/assets/data/OSSP-master.js
@@ -10,17 +10,20 @@
             "cvedetails_vendor_id": "20905"
         }, 
         "project_repos": {
-            "main_repo_id": 391939220,
             "main_github_url": "https://github.com/prometheus/prometheus",
             "main_bes_url": "https://github.com/Be-Secure/prometheus",
             "all_projects": {                                                                         
                 "prometheus": "https://github.com/prometheus/prometheus",
                 // "sub_project_xxx":""
             },
-            "all_bes_repos": {                                                                      
-                //  "sub_project_xxx":""
-                "prometheus": "https://github.com/Be-Secure/prometheus"
-           }   
+            "all_bes_repos": [                                                                  
+                {
+                    "id": 391939220,
+                    "name": "prometheus",
+                    "url": "https://github.com/Be-Secure/prometheus"
+                }
+                
+            ]
         },
         "license": {
             "key": "apache-2.0",
@@ -74,16 +77,19 @@
             "cvedetails_vendor_id": ""
         }, 
         "project_repos": {
-            "main_repo_id": 382212966,
             "main_github_url": "https://github.com/DefectDojo/django-DefectDojo",
             "main_bes_url": "https://github.com/Be-Secure/django-DefectDojo",
             "all_projects": {                                                                         
                 "django-DefectDojo" : "https://github.com/DefectDojo/django-DefectDojo",
                 // "sub_project_xxx":""
             },
-            "all_bes_repos": {                                                                      
-                 "django-DefectDojo":"https://github.com/Be-Secure/django-DefectDojo"
-           }   
+            "all_bes_repos": [
+                {   
+                    "id": 382212966,
+                    "name": "django-DefectDojo",                                                           
+                    "url": "https://github.com/Be-Secure/django-DefectDojo"
+                }   
+            ]
         },
         "license": {
             "key": "bsd-3-clause",
@@ -133,16 +139,20 @@
             "cvedetails_vendor_id": ""
         }, 
         "project_repos": {
-            "main_repo_id": 306240483,
+            
             "main_github_url": "https://github.com/hygieia/hygieia",
             "main_bes_url": "https://github.com/Be-Secure/hygieia",
             "all_projects": {                                                                         
                 "Hygieia": "https://github.com/hygieia/hygieia",
                 // "sub_project_xxx":""
             },
-            "all_bes_repos": {                                                                      
-                "Hygieia": "https://github.com/Be-Secure/hygieia",
-           }   
+            "all_bes_repos": [
+                {
+                    "id": 306240483,
+                    "name": "Hygieia",
+                    "url": "https://github.com/Be-Secure/hygieia",
+                }
+            ]
         },
         "license": {
             "key": "apache-2.0",

--- a/bes_theme/assets/data/OSSP-master.js
+++ b/bes_theme/assets/data/OSSP-master.js
@@ -119,5 +119,60 @@
         }
             
           
+    },
+    {
+        "id": 58,
+        "github_id": 306240483,
+        "bes_tracking_id": 58,
+        "name": "Hygieia",
+        "description": "CapitalOne DevOps Dashboard",
+        "cvedetails": {                                                  
+            "bes_cve_details_id": "",                      
+            "cvedetails_product_id": "",                      
+            "cvedetails_vendor_id": ""
+        }, 
+        "project_repos": {
+            "main_github_url": "https://github.com/hygieia/hygieia",
+            "main_bes_url": "https://github.com/Be-Secure/hygieia",
+            "all_projects": {                                                                         
+                "main_project_xxx" : "",
+                "sub_project_xxx":""
+            },
+            "all_bes_repos": {                                                                      
+                 "sub_project_xxx":""
+           }   
+        },
+        "license": {
+            "key": "apache-2.0",
+            "name": "Apache License 2.0",
+            "spdx_id": "Apache-2.0",
+            "url": "https://api.github.com/licenses/apache-2.0",
+            "node_id": "MDc6TGljZW5zZTI="
+          },
+        "language": [
+
+            "JavaScript",
+            "HTML",
+            "Less",
+            "Gherkin",
+            "Java",
+            "Dockerfile",
+            "Shell"
+
+        ],
+        "tags": {
+            "IND": [
+                "ALL"
+            ],
+            "COM": {
+                "Community led": "Hygieia"
+            },
+            "TD-U": [
+                "TD-U-Msg"
+            ]
+
+        }
+            
+          
     }
 ]

--- a/bes_theme/assets/data/OSSP-master.js
+++ b/bes_theme/assets/data/OSSP-master.js
@@ -1,7 +1,6 @@
 [
     {
-        "id": 50,
-        "github_id": 391939220,
+        "id": 50,      
         "bes_tracking_id": 50,
         "name": "prometheus",
         "description": "The Prometheus monitoring system and time series database.",
@@ -11,14 +10,16 @@
             "cvedetails_vendor_id": "20905"
         }, 
         "project_repos": {
+            "main_repo_id": 391939220,
             "main_github_url": "https://github.com/prometheus/prometheus",
             "main_bes_url": "https://github.com/Be-Secure/prometheus",
             "all_projects": {                                                                         
-                "main_project_xxx" : "",
-                "sub_project_xxx":""
+                "prometheus": "https://github.com/prometheus/prometheus",
+                // "sub_project_xxx":""
             },
             "all_bes_repos": {                                                                      
-                 "sub_project_xxx":""
+                //  "sub_project_xxx":""
+                "prometheus": "https://github.com/Be-Secure/prometheus"
            }   
         },
         "license": {
@@ -63,7 +64,7 @@
     },
     {
         "id": 57,
-        "github_id": 382212966,
+        
         "bes_tracking_id": 57,
         "name": "django-DefectDojo",
         "description": "DefectDojo is an open-source application vulnerability correlation and security orchestration tool.",
@@ -73,14 +74,15 @@
             "cvedetails_vendor_id": ""
         }, 
         "project_repos": {
+            "main_repo_id": 382212966,
             "main_github_url": "https://github.com/DefectDojo/django-DefectDojo",
             "main_bes_url": "https://github.com/Be-Secure/django-DefectDojo",
             "all_projects": {                                                                         
-                "main_project_xxx" : "",
-                "sub_project_xxx":""
+                "django-DefectDojo" : "https://github.com/DefectDojo/django-DefectDojo",
+                // "sub_project_xxx":""
             },
             "all_bes_repos": {                                                                      
-                 "sub_project_xxx":""
+                 "django-DefectDojo":"https://github.com/Be-Secure/django-DefectDojo"
            }   
         },
         "license": {
@@ -122,7 +124,6 @@
     },
     {
         "id": 58,
-        "github_id": 306240483,
         "bes_tracking_id": 58,
         "name": "Hygieia",
         "description": "CapitalOne DevOps Dashboard",
@@ -132,14 +133,15 @@
             "cvedetails_vendor_id": ""
         }, 
         "project_repos": {
+            "main_repo_id": 306240483,
             "main_github_url": "https://github.com/hygieia/hygieia",
             "main_bes_url": "https://github.com/Be-Secure/hygieia",
             "all_projects": {                                                                         
-                "main_project_xxx" : "",
-                "sub_project_xxx":""
+                "Hygieia": "https://github.com/hygieia/hygieia",
+                // "sub_project_xxx":""
             },
             "all_bes_repos": {                                                                      
-                 "sub_project_xxx":""
+                "Hygieia": "https://github.com/Be-Secure/hygieia",
            }   
         },
         "license": {

--- a/bes_theme/assets/data/OSSP-master.js
+++ b/bes_theme/assets/data/OSSP-master.js
@@ -60,5 +60,64 @@
         }
             
           
+    },
+    {
+        "id": 57,
+        "github_id": 382212966,
+        "bes_tracking_id": 57,
+        "name": "django-DefectDojo",
+        "description": "DefectDojo is an open-source application vulnerability correlation and security orchestration tool.",
+        "cvedetails": {                                                  
+            "bes_cve_details_id": "",                      
+            "cvedetails_product_id": "",                      
+            "cvedetails_vendor_id": ""
+        }, 
+        "project_repos": {
+            "main_github_url": "https://github.com/DefectDojo/django-DefectDojo",
+            "main_bes_url": "https://github.com/Be-Secure/django-DefectDojo",
+            "all_projects": {                                                                         
+                "main_project_xxx" : "",
+                "sub_project_xxx":""
+            },
+            "all_bes_repos": {                                                                      
+                 "sub_project_xxx":""
+           }   
+        },
+        "license": {
+            "key": "bsd-3-clause",
+            "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+            "spdx_id": "BSD-3-Clause",
+            "url": "https://api.github.com/licenses/bsd-3-clause",
+            "node_id": "MDc6TGljZW5zZTU="
+          },
+        "language": [
+
+            "HTML",
+            "Python",
+            "JavaScript",
+            "Smarty",
+            "Shell",
+            "CSS",
+            "Mustache",
+            "Batchfile"
+
+        ],
+        "tags": {
+            "IND": [
+                "ALL"
+            ],
+            "SD": [
+                "SD-SOC"
+            ],
+            "COM": {
+                "Community led": "OWASP"
+            },
+            "TD-U": [
+                "TD-U-Msg"
+            ]
+
+        }
+            
+          
     }
 ]


### PR DESCRIPTION
@panickervinod 
The structure of the repo details has been changed under "all_bes_repos"

"all_bes_repos": [                                                                  
                {
                    "id": 391939220,
                    "name": "prometheus",
                    "url": "https://github.com/Be-Secure/prometheus"
                }
                
 ]