### PR TITLE
Fixed issue: Incorrectly displaying the parent project name as part of dependencies in POI detail page

### DIFF
--- a/src/pages/BesAssessmentReport/SBOM/index.tsx
+++ b/src/pages/BesAssessmentReport/SBOM/index.tsx
@@ -29,10 +29,10 @@ export default function Sbom({ data }: any) {
   const [rowsPerPage, setRowsPerPage] = useState(15);
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [filterName, setFilterName] = useState("");
-
   let sonarqubeData: any;
   if (data?.packages) sonarqubeData = data?.packages;
   else sonarqubeData = [];
+  
   const filteredUsers = applySortFilter(
     sonarqubeData,
     getComparator("desc", "name"),

--- a/src/pages/BesAssessmentReport/index.tsx
+++ b/src/pages/BesAssessmentReport/index.tsx
@@ -24,7 +24,7 @@ export const spanStyle: any = {
   paddingRight: "13px",
 };
 
-function displayReport(besReport: any, report: any): any {
+function displayReport(BeSName: string, besReport: any, report: any): any {
   if (besReport === "Scorecard") {
     return <ScorecardTable data={report} />;
   }
@@ -38,7 +38,7 @@ function displayReport(besReport: any, report: any): any {
     return <Fossology data={report} />;
   }
   if (besReport === "SBOM") {
-    return <Sbom data={report} />;
+    return <Sbom data={report}/>;
   }
 }
 
@@ -73,7 +73,7 @@ function BesAssessmentReport() {
         <Grid container spacing={6}>
           <Grid item xs={12}>
             <Card sx={{mx: { xs: 2, lg: 3 }}}>
-              <MKBox >{displayReport(besReport, report)}</MKBox>
+              <MKBox >{displayReport(besName, besReport, report)}</MKBox>
             </Card>
           </Grid>
         </Grid>

--- a/src/pages/BesVersionHistory/AssessmentReport/index.tsx
+++ b/src/pages/BesVersionHistory/AssessmentReport/index.tsx
@@ -1106,7 +1106,7 @@ const GetAssessmentData = ({ version, name, report, itemData, masterData }: any)
         {flag ? (
           "No dependent packages are available"
         ) : (
-        "Not Available"
+        "Assessment report not available"
         )}
     </MKTypography>
   );

--- a/src/pages/BesVersionHistory/AssessmentReport/index.tsx
+++ b/src/pages/BesVersionHistory/AssessmentReport/index.tsx
@@ -706,7 +706,7 @@ const FetchSBOM = ({data, masterData, name}: any) => {
         {tracked.length !== 0 ? (
           <b key={`BOLDSBOM1`}>Tracked under BeS :</b>
         ) : (
-        <b key={`BOLDSBOM1`}>No dependencies are tracked under BeS</b>
+        <b key={`BOLDSBOM1`}>No dependencies tracked under BeS</b>
         )}
         
       </MKTypography>

--- a/src/pages/BesVersionHistory/AssessmentReport/index.tsx
+++ b/src/pages/BesVersionHistory/AssessmentReport/index.tsx
@@ -671,7 +671,6 @@ const FetchSBOM = ({data, masterData, name}: any) => {
       }
     });
   });
-  //console.log("tra: ",tracked);
   dis = tracked.map(function (td: string, index: number) {
     return (<>
       <Grid item
@@ -695,7 +694,8 @@ const FetchSBOM = ({data, masterData, name}: any) => {
   return (<>
     <Grid key={`GRIDSBOMMAIN`}
       style={{ minWidth: "200px" }}>
-      <MKTypography key="MKTypoSBOMMain" variant="body1"
+      {tracked.length !== 0 ? (
+        <MKTypography key="MKTypoSBOMMain" variant="body1"
         color="inherit"
         style={{
           fontSize: "12px",
@@ -703,13 +703,19 @@ const FetchSBOM = ({data, masterData, name}: any) => {
           display: "flex",
           paddingLeft: "calc(0.1rem + 0.3vw)"
         }}>
-        {tracked.length !== 0 ? (
-          <b key={`BOLDSBOM1`}>Tracked under BeS :</b>
-        ) : (
-        <b key={`BOLDSBOM1`}>No dependencies tracked under BeS</b>
-        )}
+          <b key={`BOLDSBOM1`}>Tracked under BeS :</b>  
+        </MKTypography>
+      ) : (
+        <MKTypography key="MKTypoSBOMMain" variant="body1"
+        color="inherit"
         
-      </MKTypography>
+        style={{
+        fontSize: "12px", display: "flex",
+        justifyContent: "center", alignItems: "center", position: "relative", top: "55px"
+        }}>
+          <b key={`BOLDSBOM1`}>No dependencies tracked under BeS</b>
+        </MKTypography>
+      )}
       <Grid key={`GRIDSBOMSUBMAIN`}
         container>
         {dis}
@@ -1047,43 +1053,48 @@ const GetAssessmentData = ({ version, name, report, itemData, masterData }: any)
       </>
     );
   }
-
-  if (report === "Dependencies" && jsonDataLength !== 0 && !(jsonData.packages.length === 1 && jsonData.packages[0].name === name)) {
-    return (<>
-      <Typography variant="h6"
-        key="TYPOSBOMMAIN1"
-        color="inherit"
-        style={{
-          fontSize: "calc(0.6rem + 0.5vw)"
-        }}>
-        <Link to={myObject}
-          key="LINKSBOMMAIN1"
+  let flag = false;
+  if (report === "Dependencies" && jsonDataLength !== 0) {
+    if (!(jsonData.packages.length === 1 && jsonData.packages[0].name === name)){
+      return (<>
+        <Typography variant="h6"
+          key="TYPOSBOMMAIN1"
+          color="inherit"
           style={{
-            fontSize: "calc(0.6rem + 0.5vw)",
-            display: "flex",
-            justifyContent: "center"
+            fontSize: "calc(0.6rem + 0.5vw)"
           }}>
-          {(jsonData.packages.length)-1}
-        </Link>
-      </Typography>
-      <Grid key="GRIDSBOMMAIN1"
-        style={{
-          height: "100px",
-          borderRadius: "3px"
-        }}
-        sx={{ overflowY: "scroll" }}>
-        <MKBox key="MKBOXSBOMMAIN1">
-          <FetchSBOM
-            data={jsonData.packages}
-            masterData={masterData}
-            name={name}
-          />
-        </MKBox>
-      </Grid>
-    </>
-    );
+          <Link to={myObject}
+            key="LINKSBOMMAIN1"
+            style={{
+              fontSize: "calc(0.6rem + 0.5vw)",
+              display: "flex",
+              justifyContent: "center"
+            }}>
+            {(jsonData.packages.length)-1}
+          </Link>
+        </Typography>
+        <Grid key="GRIDSBOMMAIN1"
+          style={{
+            height: "100px",
+            borderRadius: "3px"
+          }}
+          sx={{ overflowY: "scroll" }}>
+          <MKBox key="MKBOXSBOMMAIN1">
+            <FetchSBOM
+              data={jsonData.packages}
+              masterData={masterData}
+              name={name}
+            />
+          </MKBox>
+        </Grid>
+      </>
+      );
+    } else {
+      flag = true;
+    }
+    
   }
-
+ 
   return (
     <MKTypography variant="h6"
       key="TYPOSBOMMAINBLANK1"
@@ -1092,7 +1103,11 @@ const GetAssessmentData = ({ version, name, report, itemData, masterData }: any)
         fontSize: "12px", display: "flex",
         justifyContent: "center", alignItems: "center", position: "relative", top: "67px"
       }}>
-      Not Available
+        {flag ? (
+          "No dependent packages are available"
+        ) : (
+        "Not Available"
+        )}
     </MKTypography>
   );
 };

--- a/src/pages/BesVersionHistory/AssessmentReport/index.tsx
+++ b/src/pages/BesVersionHistory/AssessmentReport/index.tsx
@@ -671,7 +671,7 @@ const FetchSBOM = ({data, masterData, name}: any) => {
       }
     });
   });
-
+  //console.log("tra: ",tracked);
   dis = tracked.map(function (td: string, index: number) {
     return (<>
       <Grid item
@@ -692,7 +692,6 @@ const FetchSBOM = ({data, masterData, name}: any) => {
     </>
     );
   });
-
   return (<>
     <Grid key={`GRIDSBOMMAIN`}
       style={{ minWidth: "200px" }}>
@@ -704,7 +703,12 @@ const FetchSBOM = ({data, masterData, name}: any) => {
           display: "flex",
           paddingLeft: "calc(0.1rem + 0.3vw)"
         }}>
-        <b key={`BOLDSBOM1`}>Tracked under BeS :</b>
+        {tracked.length !== 0 ? (
+          <b key={`BOLDSBOM1`}>Tracked under BeS :</b>
+        ) : (
+        <b key={`BOLDSBOM1`}>No dependencies are tracked under BeS</b>
+        )}
+        
       </MKTypography>
       <Grid key={`GRIDSBOMSUBMAIN`}
         container>
@@ -1045,7 +1049,6 @@ const GetAssessmentData = ({ version, name, report, itemData, masterData }: any)
   }
 
   if (report === "Dependencies" && jsonDataLength !== 0 && !(jsonData.packages.length === 1 && jsonData.packages[0].name === name)) {
-    console.log("data: ",jsonData);
     return (<>
       <Typography variant="h6"
         key="TYPOSBOMMAIN1"

--- a/src/pages/BesVersionHistory/AssessmentReport/index.tsx
+++ b/src/pages/BesVersionHistory/AssessmentReport/index.tsx
@@ -655,14 +655,14 @@ const FetchSBOM = ({data, masterData, name}: any) => {
   let tracked: string[] = [];
   let dis: any = {};
   data.forEach((dp) => {
-    if(dp.name === name){
+    if(dp.name.toLowerCase() === name.toLowerCase()){
       return;
     }
     masterData.forEach((tp) => {
       let duplicate: boolean = false;
-      if (dp.name === tp.name) {
+      if (dp.name.toLowerCase() === tp.name.toLowerCase()) {
         tracked.forEach((tmptracked) => {
-          if (tmptracked === dp.name)
+          if (tmptracked.toLowerCase() === dp.name.toLowerCase())
             duplicate = true;
         });
 
@@ -1055,7 +1055,7 @@ const GetAssessmentData = ({ version, name, report, itemData, masterData }: any)
   }
   let flag = false;
   if (report === "Dependencies" && jsonDataLength !== 0) {
-    if (!(jsonData.packages.length === 1 && jsonData.packages[0].name === name)){
+    if (!(jsonData.packages.length === 1 && jsonData.packages[0].name.toLowerCase() === name.toLowerCase())){
       return (<>
         <Typography variant="h6"
           key="TYPOSBOMMAIN1"

--- a/src/pages/BesVersionHistory/AssessmentReport/index.tsx
+++ b/src/pages/BesVersionHistory/AssessmentReport/index.tsx
@@ -1044,7 +1044,8 @@ const GetAssessmentData = ({ version, name, report, itemData, masterData }: any)
     );
   }
 
-  if (report === "Dependencies" && jsonDataLength !== 0) {
+  if (report === "Dependencies" && jsonDataLength !== 0 && !(jsonData.packages.length === 1 && jsonData.packages[0].name === name)) {
+    console.log("data: ",jsonData);
     return (<>
       <Typography variant="h6"
         key="TYPOSBOMMAIN1"

--- a/src/pages/BesVersionHistory/AssessmentReport/index.tsx
+++ b/src/pages/BesVersionHistory/AssessmentReport/index.tsx
@@ -574,7 +574,6 @@ const FetchLicense = ({ data, uniq_lic, itemData }: any) => {
       ld.LicenseConcluded.length === 0))
       non_lic_files++;
   });
-  //console.log("item data=" + JSON.stringify(itemData));
   if (itemData.license && itemData.license.key) {
     project_lcesnse = itemData.license.key;
   }
@@ -652,12 +651,13 @@ const FetchLicense = ({ data, uniq_lic, itemData }: any) => {
   }
 };
 
-const FetchSBOM = ({ data, masterData }: any) => {
-
+const FetchSBOM = ({data, masterData, name}: any) => {
   let tracked: string[] = [];
   let dis: any = {};
-
   data.forEach((dp) => {
+    if(dp.name === name){
+      return;
+    }
     masterData.forEach((tp) => {
       let duplicate: boolean = false;
       if (dp.name === tp.name) {
@@ -722,7 +722,6 @@ const GetAssessmentData = ({ version, name, report, itemData, masterData }: any)
   let reportNameMap = "";
   let reportNameMapCodeql = "";
   let reportNameMapSonar = "";
-
 
   if (report === "Criticality Score") {
     reportNameMap = "Criticality Score";
@@ -1060,7 +1059,7 @@ const GetAssessmentData = ({ version, name, report, itemData, masterData }: any)
             display: "flex",
             justifyContent: "center"
           }}>
-          {jsonData.packages.length}
+          {(jsonData.packages.length)-1}
         </Link>
       </Typography>
       <Grid key="GRIDSBOMMAIN1"
@@ -1073,6 +1072,7 @@ const GetAssessmentData = ({ version, name, report, itemData, masterData }: any)
           <FetchSBOM
             data={jsonData.packages}
             masterData={masterData}
+            name={name}
           />
         </MKBox>
       </Grid>


### PR DESCRIPTION
Fixed https://github.com/Be-Secure/BeSLighthouse/issues/530
 
1. Fixed issue- Now parent project name will not display in dependencies in the POI project card.
2. If there are no dependencies tracked under BeS, it will display "No dependencies tracked under BeS".
3. If the SBOM report is available with only one dependent package, which is the root/parent package, it will display "No dependent packages are available". 