### PR TITLE
Added color grading for OpenSSF Scorecard score

### DIFF
--- a/src/pages/BesVersionHistory/AssessmentReport/index.tsx
+++ b/src/pages/BesVersionHistory/AssessmentReport/index.tsx
@@ -847,20 +847,30 @@ const GetAssessmentData = ({ version, name, report, itemData, masterData }: any)
     };
   }
   if (report === "ScoreCard" && jsonDataLength !== 0) {
+    let color_code = "";
+    let risk_level = "";
+    if (jsonData.score >= 0 && jsonData.score <= 2){
+      color_code = "#008000";
+      risk_level = "Low risk";
+    } else if (jsonData.score > 2 && jsonData.score <= 5) {
+      color_code = "#FFC300";
+      risk_level = "Medium risk";
+    } else if (jsonData.score > 5 && jsonData.score <= 7.5) {
+      color_code="#FF5733";
+      risk_level = "High risk";
+    } else if (jsonData.score > 7.5 && jsonData.score <= 10) {
+      color_code = "#C70039";
+      risk_level = "Critical risk";
+    }
     return (<>
       {/* Display scorecard score */}
       <Typography variant="h6"
         key={`TypoSC1`}
         color="inherit"
-        style={{ fontSize: "15px" }}>
-        <Link to={myObject}
-          key={`LinkSC1`}
-          style={{
-            fontSize: "calc(0.6rem + 0.5vw)",
-            display: "flex",
-            justifyContent: "center"
-          }}>
-          {jsonData.score}
+        style={{ fontSize: "15px", marginLeft: "20px" }}>
+        <Link to={myObject} key={`LinkSC1`} style={{ fontSize: "calc(0.6rem + 0.5vw)", display: "flex", justifyContent: "center" }}>
+            <span style={{ color: color_code }}>{jsonData.score}</span>
+            <span style={{ fontSize: "11px", color: "black" }}>&nbsp;({risk_level})</span>
         </Link>
       </Typography>
       {/* Scorecard data */}


### PR DESCRIPTION
https://github.com/Be-Secure/BeSLighthouse/issues/555

Low risk: 0 to 2 (`#008000`)
Medium risk: 2.1 to 5 (`#FFC300`)
High risk: 5.1 to 7.5 (`#FF5733`)
Critical risk: 7.6 to 10 (`#C70039`)

![Screenshot from 2024-02-02 16-51-23](https://github.com/Be-Secure/BeSLighthouse/assets/125947785/b68474f4-4053-4f8c-937d-c58ea3dd4cc2)
![Screenshot from 2024-02-02 16-50-54](https://github.com/Be-Secure/BeSLighthouse/assets/125947785/4f0e03e2-7d01-4d5b-b403-187d48856be0)
