### PR TITLE
Fixed criticality score data fetch issue

### DIFF
--- a/src/pages/BesVersionHistory/AssessmentReport/index.tsx
+++ b/src/pages/BesVersionHistory/AssessmentReport/index.tsx
@@ -148,15 +148,28 @@ const FetchCS = ({ data }: any) => {
     "Closed Issues",
     "Last Updated",
   ];
-  tableData = [
-    {
-      "Age(in months)": data.created_since,
-      Contributors: data.contributor_count,
-      Organizations: data.org_count,
-      "Closed Issues": data.closed_issues_count,
-      "Last Updated": data.updated_since,
-    },
-  ];
+
+  if ('default_score' in data) {
+    tableData = [
+      {
+        "Age(in months)": data.legacy.created_since,
+        Contributors: data.legacy.contributor_count,
+        Organizations: data.legacy.org_count,
+        "Closed Issues": data.legacy.closed_issues_count,
+        "Last Updated": data.legacy.updated_since,
+      },
+    ];
+  } else if ('criticality_score' in data) {
+    tableData = [
+      {
+        "Age(in months)": data.created_since,
+        Contributors: data.contributor_count,
+        Organizations: data.org_count,
+        "Closed Issues": data.closed_issues_count,
+        "Last Updated": data.updated_since,
+      },
+    ];
+  }
   return (
     <>
       <MKTypography

--- a/src/pages/BesVersionHistory/AssessmentReport/index.tsx
+++ b/src/pages/BesVersionHistory/AssessmentReport/index.tsx
@@ -443,26 +443,30 @@ function GetAssessmentData(version, name, report, itemData, masterData) {
 
   if (report === "Criticality Score" && jsonDataLength !== 0) {
     let color_code = "";
-
     let risk_level = "";
-
+    let criticality_score: any = 0.0;
+    if ('default_score' in jsonData) {
+      criticality_score = parseFloat(jsonData["default_score"]);
+    } else if ('criticality_score' in jsonData) {
+      criticality_score = jsonData["criticality_score"];
+    }
     if (
-      jsonData.criticality_score.toFixed(2) >= 0.1 &&
-      jsonData.criticality_score.toFixed(2) < 0.4
+      criticality_score.toFixed(2) >= 0.1 &&
+      criticality_score.toFixed(2) < 0.4
     ) {
       color_code = "#008000";
 
       risk_level = "Low risk";
     } else if (
-      jsonData.criticality_score.toFixed(2) >= 0.4 &&
-      jsonData.criticality_score.toFixed(2) < 0.6
+      criticality_score.toFixed(2) >= 0.4 &&
+      criticality_score.toFixed(2) < 0.6
     ) {
       color_code = "#FFC300";
 
       risk_level = "Medium risk";
     } else if (
-      jsonData.criticality_score.toFixed(2) >= 0.6 &&
-      jsonData.criticality_score.toFixed(2) <= 1.0
+      criticality_score.toFixed(2) >= 0.6 &&
+      criticality_score.toFixed(2) <= 1.0
     ) {
       color_code = "#FF5733";
 
@@ -470,7 +474,7 @@ function GetAssessmentData(version, name, report, itemData, masterData) {
     }
 
     return (data_array = [
-      jsonData.criticality_score.toFixed(2),
+      criticality_score.toFixed(2),
       <FetchCS data={jsonData} />,
       color_code,
       "",


### PR DESCRIPTION
Fixed https://github.com/Be-Secure/BeSLighthouse/issues/603

**Root cause:** Previously criticality_score was generated by an old version of criticality, currently we have updated BeS-dev-kit to generate criticality_score using the latest version of the tool. There is a schema change in the latest version of the criticality tool. Currently, BeSLighthouse code is unable to fetch data from the criticality_score report that BeS-dev-kit generates. For the mentioned reason BeSLighthouse code was breaking.

**Resolution:** Updated code to fetch data from new criticality_score schema. Using this update BeSLighthouse can fetch data from both json schema (old and new).


![Screenshot from 2024-02-29 14-15-30](https://github.com/Be-Secure/BeSLighthouse/assets/125947785/46d1b753-a601-464c-b48a-ba7acbf43422)
